### PR TITLE
feat(docs): add storage link on doc navigation

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -125,6 +125,11 @@ const sidebars: SidebarsConfig = {
       ]
     },
     {
+      type: 'doc',
+      label: '🪣 Storage',
+      id: 's3-storage'
+    },
+    {
       type: 'category',
       label: '🎓 Quick starts',
       items: [


### PR DESCRIPTION
Add S3 Storage doc. Related to the following doc PR : https://github.com/mnfst/docs/pull/20